### PR TITLE
Fix broken side bar links for "Home", "People", and "Resources"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,10 +19,10 @@
         <a href="{{ site.github.owner_url }}"><img src="{{site.logo | relative_url}}" alt="Logo" /> </a>
         {% endif %}
 
-        <p align="center"><a href="./index">Home</a></p>
-        <p align="center"><a href="./people">People</a></p>
-        <p align="center"><a href="./publications">Publications</a></p>
-        <p align="center"><a href="./resources">Resources</a></p>
+        <p align="center"><a href="{{ '/index' | relative_url }}">Home</a></p>
+        <p align="center"><a href="{{ '/people' | relative_url }}">People</a></p>
+        <p align="center"><a href="{{ '/publications' | relative_url }}">Publications</a></p>
+        <p align="center"><a href="{{ '/resources' | relative_url }}">Resources</a></p>
         <hr>
         
         <p>{{ site.description | default: site.github.project_tagline }}</p>


### PR DESCRIPTION
This PR fixes broken sidebar links for "Home," "People," and "Resources," ensuring proper navigation to the intended pages.